### PR TITLE
Fixed title bar css bug

### DIFF
--- a/skin/osx/osx.css
+++ b/skin/osx/osx.css
@@ -12,6 +12,10 @@
     height: 44px !important;
 }
 
+#titlebar {
+  background: var(--chrome-background-color);
+}
+
 .tabbrowser-tabs {
     margin: 0 !important;
     padding: 0 !important;


### PR DESCRIPTION
resolves #11

Before: 
<img width="1512" alt="screen shot 2016-06-06 at 8 05 26 pm" src="https://cloud.githubusercontent.com/assets/2600677/15841817/063fd8b0-2c22-11e6-8491-d5d9c383ac19.png">

After:
<img width="1512" alt="screen shot 2016-06-23 at 6 52 27 pm" src="https://cloud.githubusercontent.com/assets/2600677/16322825/f2e1797c-3973-11e6-97fb-12bd9df2e547.png">

Everything still looks fine in normal firefox since it's using `--chrome-background-color`.
